### PR TITLE
Add rspec shared examples and update README

### DIFF
--- a/lib/message_queue_consumer/support/shared_examples_for_message_processor.rb
+++ b/lib/message_queue_consumer/support/shared_examples_for_message_processor.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples "a message processor" do
+  # set the subject in your own tests
+  it "implements #process" do
+    expect(subject).to respond_to(:process)
+  end
+
+  it "accepts 1 argument for #process" do
+    expect(subject.method(:process).arity).to eq(1)
+  end
+end


### PR DESCRIPTION
After https://github.com/alphagov/message-queue-consumer/pull/1 was merged, an attempt at using the gem found some improvements would be helpful.

This PR adds shared examples to simplify testing the client specific message processor, and updates examples and wording in the README.

Part of ticket: https://trello.com/c/z8b6VmCU/317-update-panopticon-when-links-are-sent-to-publishing-api