### PR TITLE
Set the version number for the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.9.0
+
+- Initial implementation of the gem

--- a/lib/message_queue_consumer/version.rb
+++ b/lib/message_queue_consumer/version.rb
@@ -1,3 +1,3 @@
 module MessageQueueConsumer
-  VERSION = '0.0.0'
+  VERSION = '0.9.0'
 end


### PR DESCRIPTION
Need to set an initial version of the gem. There will probably be other tweaks to it, so decided not to choose 1.0.0…

Also add a changelog for future changes.

Part of ticket: https://trello.com/c/z8b6VmCU/317-update-panopticon-when-links-are-sent-to-publishing-api